### PR TITLE
feat: add global store with context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { StoreProvider } from './state/Store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <StoreProvider>
+      <App />
+    </StoreProvider>
   </React.StrictMode>
 );
 

--- a/src/state/Store.js
+++ b/src/state/Store.js
@@ -1,0 +1,51 @@
+import React, { createContext, useReducer, useContext } from 'react';
+
+// Initial global state
+const initialState = {
+  user: null,
+  profile: null,
+  match: null,
+};
+
+// Reducer function to handle state changes
+function reducer(state, action) {
+  switch (action.type) {
+    case 'SET_USER':
+      return { ...state, user: action.payload };
+    case 'SET_PROFILE':
+      return { ...state, profile: action.payload };
+    case 'SET_MATCH':
+      return { ...state, match: action.payload };
+    default:
+      return state;
+  }
+}
+
+// Create context
+const StoreContext = createContext();
+
+// Provider component
+export function StoreProvider({ children }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setUser = (user) => dispatch({ type: 'SET_USER', payload: user });
+  const setProfile = (profile) => dispatch({ type: 'SET_PROFILE', payload: profile });
+  const setMatch = (match) => dispatch({ type: 'SET_MATCH', payload: match });
+
+  return (
+    <StoreContext.Provider value={{ state, setUser, setProfile, setMatch }}>
+      {children}
+    </StoreContext.Provider>
+  );
+}
+
+// Custom hook to use the store
+export function useStore() {
+  const context = useContext(StoreContext);
+  if (context === undefined) {
+    throw new Error('useStore must be used within a StoreProvider');
+  }
+  return context;
+}
+
+export default StoreContext;


### PR DESCRIPTION
## Summary
- add Store context with user, profile, and match state
- wrap App with StoreProvider to expose global state

## Testing
- `npm test -- --watchAll=false` *(fails: Firebase Error auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68abd232f200832184006092be8c625c