### PR TITLE
Add Firestore rules and CI deployment

### DIFF
--- a/.github/workflows/deploy-firestore-rules.yml
+++ b/.github/workflows/deploy-firestore-rules.yml
@@ -1,0 +1,21 @@
+name: Deploy Firestore Rules
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'firestore.rules' ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm install -g firebase-tools
+      - run: firebase deploy --only firestore:rules --project $FIREBASE_PROJECT_ID
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/README.md
+++ b/README.md
@@ -105,3 +105,16 @@ This project is licensed under the MIT License.
 - Never commit `.env.local` files to version control
 - Keep Firebase API keys secure
 - Use environment variables for all sensitive configuration
+
+## Firestore Security Rules
+
+The project defines Firestore rules in `firestore.rules` to protect user data:
+
+- Authenticated users may read any user profile but can only modify their own document.
+- Chat documents and their messages are readable and writable only by users listed in the chat's `users` array.
+
+Deploy rule updates with the Firebase CLI:
+
+```bash
+firebase deploy --only firestore:rules
+```

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,20 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Users can read any user profile but may only modify their own document
+    match /users/{userId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Chats are visible only to participants
+    match /chats/{chatId} {
+      allow read, write: if request.auth != null && request.auth.uid in resource.data.users;
+
+      // Messages inherit chat permissions
+      match /messages/{messageId} {
+        allow read, write: if request.auth != null && request.auth.uid in get(/databases/$(database)/documents/chats/$(chatId)).data.users;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore security rules restricting profile and chat access
- document rule behavior in README
- create workflow to deploy Firestore rules via Firebase CLI

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68abd361b9f08321976f9180dff3d3b6