### PR TITLE
Reorder matching test import

### DIFF
--- a/src/__tests__/matching.test.js
+++ b/src/__tests__/matching.test.js
@@ -1,6 +1,5 @@
-jest.mock('../firebase/init', () => ({ db: {} }));
-
 import { calculateCompatibility } from '../matching/MatchView';
+jest.mock('../firebase/init', () => ({ db: {} }));
 
 describe('calculateCompatibility', () => {
   it('calculates score and insights', () => {


### PR DESCRIPTION
## Summary
- move calculateCompatibility import above firebase mock
- ensure mock immediately follows import

## Testing
- `npx eslint src/__tests__/matching.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abe8a9d49c8321974f0a6a40adfe39