### PR TITLE
refactor: use named Sentry imports

### DIFF
--- a/env.template
+++ b/env.template
@@ -5,3 +5,6 @@ REACT_APP_FIREBASE_PROJECT_ID=your_project_id_here
 REACT_APP_FIREBASE_STORAGE_BUCKET=your_storage_bucket_here
 REACT_APP_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id_here
 REACT_APP_FIREBASE_APP_ID=your_app_id_here
+SENTRY_DSN=your_sentry_dsn_here
+# For Create React App builds
+REACT_APP_SENTRY_DSN=your_sentry_dsn_here

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "roomie-ai",
       "version": "0.1.0",
       "dependencies": {
+        "@sentry/react": "^10.5.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
@@ -3899,6 +3900,98 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "license": "MIT"
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.5.0.tgz",
+      "integrity": "sha512-4KIJdEj/8Ip9yqJleVSFe68r/U5bn5o/lYUwnFNEnDNxmpUbOlr7x3DXYuRFi1sfoMUxK9K1DrjnBkR7YYF00g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.5.0.tgz",
+      "integrity": "sha512-x79P4VZwUxb1EGZb9OQ5EEgrDWFCUlrbzHBwV/oocQA5Ss1SFz5u6cP5Ak7yJtILiJtdGzAyAoQOy4GKD13D4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.5.0.tgz",
+      "integrity": "sha512-Dp4coE/nPzhFrYH3iVrpVKmhNJ1m/jGXMEDBCNg3wJZRszI41Hrj0jCAM0Y2S3Q4IxYOmFYaFbGtVpAznRyOHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.5.0",
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.5.0.tgz",
+      "integrity": "sha512-5nrRKd5swefd9+sFXFZ/NeL3bz/VxBls3ubAQ3afak15FikkSyHq3oKRKpMOtDsiYKXE3Bc0y3rF5A+y3OXjIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.5.0",
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.5.0.tgz",
+      "integrity": "sha512-o5pEJeZ/iZ7Fmaz2sIirThfnmSVNiP5ZYhacvcDi0qc288TmBbikCX3fXxq3xiSkhXfe1o5QIbNyovzfutyuVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.5.0",
+        "@sentry-internal/feedback": "10.5.0",
+        "@sentry-internal/replay": "10.5.0",
+        "@sentry-internal/replay-canvas": "10.5.0",
+        "@sentry/core": "10.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.5.0.tgz",
+      "integrity": "sha512-jTJ8NhZSKB2yj3QTVRXfCCngQzAOLThQUxCl9A7Mv+XF10tP7xbH/88MVQ5WiOr2IzcmrB9r2nmUe36BnMlLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.5.0.tgz",
+      "integrity": "sha512-UHanvg+oIAvE/Hm76QCCdxYgb+tIuF0JszQoROApl5C5RxRfJJcU643pASQs6BDvrtxbuMQ/AHTacLTYpsn0cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.5.0",
+        "@sentry/core": "10.5.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -9617,6 +9710,21 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hoopy": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@sentry/react": "^10.5.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { BrowserRouter as Router, Routes, Route, NavLink, Navigate, useNavigate, useLocation } from 'react-router-dom';
+import { captureException } from '@sentry/react';
 import { doc, setDoc, collection, query, where, onSnapshot } from 'firebase/firestore';
 import { signOut } from 'firebase/auth';
 import useAuth from './auth/useAuth';
@@ -73,6 +74,7 @@ function AppRoutes() {
       navigate('/matches');
     } catch (error) {
       console.error('Error updating profile:', error);
+        captureException(error);
     }
   };
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
+jest.mock('@sentry/react', () => ({ captureException: jest.fn(), init: jest.fn() }));
 jest.mock('./auth/useAuth', () => ({
   __esModule: true,
   default: jest.fn(() => ({ user: null, userData: null, loading: true })),

--- a/src/__tests__/auth.test.js
+++ b/src/__tests__/auth.test.js
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import AuthView from '../auth/AuthView';
 
+jest.mock('@sentry/react', () => ({ captureException: jest.fn(), init: jest.fn() }));
 jest.mock('../firebase/init', () => ({ auth: {} }));
 
 const mockSignIn = jest.fn(() => Promise.resolve());

--- a/src/__tests__/chat.test.js
+++ b/src/__tests__/chat.test.js
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import ChatView from '../chat/ChatView';
 
+jest.mock('@sentry/react', () => ({ captureException: jest.fn(), init: jest.fn() }));
 jest.mock('../firebase/init', () => ({ db: {} }));
 
 jest.mock('firebase/firestore', () => ({

--- a/src/__tests__/matching.test.js
+++ b/src/__tests__/matching.test.js
@@ -1,3 +1,4 @@
+jest.mock('@sentry/react', () => ({ captureException: jest.fn(), init: jest.fn() }));
 jest.mock('../firebase/init', () => ({ db: {} }));
 
 import { calculateCompatibility } from '../matching/MatchView';

--- a/src/chat/ChatView.js
+++ b/src/chat/ChatView.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { captureException } from '@sentry/react';
 import { doc, getDoc, setDoc, collection, query, orderBy, onSnapshot, addDoc, serverTimestamp, updateDoc } from 'firebase/firestore';
 import { db } from '../firebase/init';
 import { BackIcon, SendIcon } from '../icons';
@@ -50,12 +51,13 @@ const ChatView = ({ currentUserData }) => {
             }
           });
         });
-      } catch (error) {
-        console.error('Error fetching matches:', error);
-        if (isMounted) {
-          setLoading(false);
+        } catch (error) {
+          console.error('Error fetching matches:', error);
+          captureException(error);
+          if (isMounted) {
+            setLoading(false);
+          }
         }
-      }
     };
     
     fetchMatches();
@@ -67,9 +69,10 @@ const ChatView = ({ currentUserData }) => {
         if (typeof unsubscribe === 'function') {
           try {
             unsubscribe();
-          } catch (error) {
-            console.error('Error unsubscribing from chat listener:', error);
-          }
+            } catch (error) {
+              console.error('Error unsubscribing from chat listener:', error);
+              captureException(error);
+            }
         }
       });
     };
@@ -136,9 +139,10 @@ const ChatWindow = ({ currentUserData, matchData, onBack }) => {
           [`unreadCounts.${currentUserData.uid}`]: 0
         });
         console.log('✅ Unread count reset to 0 for user:', currentUserData.uid);
-      } catch (error) {
-        console.error('Error resetting unread count:', error);
-      }
+        } catch (error) {
+          console.error('Error resetting unread count:', error);
+          captureException(error);
+        }
     };
 
     resetUnreadCount();
@@ -192,9 +196,10 @@ const ChatWindow = ({ currentUserData, matchData, onBack }) => {
       
       console.log('✅ Message sent and unread count incremented for:', matchData.uid);
       console.log('📊 Updated unread counts:', currentUnreadCounts);
-    } catch (error) {
-      console.error('❌ Error sending message:', error);
-    }
+      } catch (error) {
+        console.error('❌ Error sending message:', error);
+        captureException(error);
+      }
     
     setNewMessage('');
     setLoading(false);

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { init as initSentry } from '@sentry/react';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { StoreProvider } from './state/Store';
+
+const dsn = process.env.REACT_APP_SENTRY_DSN || process.env.SENTRY_DSN;
+if (dsn) {
+  initSentry({ dsn });
+}
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- refactor Sentry initialization to named import to avoid redeclaration
- import captureException directly in components and report Firestore errors

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68abe3d9e66483219afaa1ca2f89b722