### PR TITLE
fix: remove duplicate Sentry import and init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,11 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { StoreProvider } from './state/Store';
-import * as Sentry from '@sentry/react';
 
 // Support both SENTRY_DSN and REACT_APP_SENTRY_DSN for CRA compatibility
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.REACT_APP_SENTRY_DSN;
 if (SENTRY_DSN) {
   Sentry.init({ dsn: SENTRY_DSN });
-}
-
-const dsn = process.env.REACT_APP_SENTRY_DSN || process.env.SENTRY_DSN;
-if (dsn) {
-  Sentry.init({ dsn });
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
## Summary
- remove duplicate `@sentry/react` import and redundant init block

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abf6bc6a548321b5969bd1c96f8889