### PR TITLE
Add Firebase Storage image upload with AI analysis placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A React-based roommate matching app that uses AI analysis and Firebase for real-
 - 💬 Real-time chat with matches
 - 🎯 AI-powered personality analysis
 - 👥 Smart roommate matching algorithm
-- 📸 Photo upload and analysis (simulated)
+- 📸 Photo upload to Firebase Storage with placeholder AI analysis
 
 ## Prerequisites
 
@@ -41,8 +41,13 @@ A React-based roommate matching app that uses AI analysis and Firebase for real-
 4. **Firebase Setup**
    - Create a Firebase project at [Firebase Console](https://console.firebase.google.com/)
    - Enable Authentication (Email/Password)
-   - Enable Firestore Database
+   - Enable Firestore Database and Storage
    - Copy your config values to `.env.local`
+   - Configure Firebase Storage CORS for local development using the provided `storage-cors.json`:
+
+     ```bash
+     gsutil cors set storage-cors.json gs://<your-storage-bucket>
+     ```
 
 5. **Start the development server**
    ```bash

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import AuthView from './auth/AuthView';
 import MatchView from './matching/MatchView';
 import ChatView from './chat/ChatView';
 import { auth, db } from './firebase/init';
+import ImageUpload from './profile/ImageUpload';
 import { HeartIcon, ChatIcon, UserIcon } from './icons';
 import { playNotificationSound } from './notifications/notifications';
 
@@ -127,7 +128,6 @@ const OnboardingScreen = ({ onProfileUpdate }) => {
         importantInRoommate: '',
         photos: [], likes: [], passes: [], matches: [],
     });
-    const [aiLoading, setAiLoading] = useState(false);
 
     const handleNext = () => setStep(s => s + 1);
     const handleBack = () => setStep(s => s - 1);
@@ -141,17 +141,6 @@ const OnboardingScreen = ({ onProfileUpdate }) => {
                 : [...currentPrefs, gender];
             return { ...prev, matchingPreferences: { ...prev.matchingPreferences, gender: newPrefs } };
         });
-    };
-    const simulateAIAnalysis = async () => {
-        setAiLoading(true);
-        await new Promise(resolve => setTimeout(resolve, 2000)); 
-        const mockAnalysis = {
-            description: "Based on your photos, you seem to have an appreciation for nature and a calm, friendly demeanor. You likely enjoy both quiet evenings and occasional outings.",
-            tags: ["Nature-Lover", "Friendly", "Calm", "Social"],
-        };
-        setFormData(prev => ({ ...prev, aiAnalysis: mockAnalysis }));
-        setAiLoading(false);
-        handleNext();
     };
     const handleSubmit = () => onProfileUpdate(formData);
 
@@ -167,11 +156,10 @@ const OnboardingScreen = ({ onProfileUpdate }) => {
                     <div className="space-y-4 text-center">
                         <h3 className="text-2xl font-bold">Upload Your Photos</h3>
                         <p className="text-gray-600">Our AI will analyze them to find better matches.</p>
-                        <label htmlFor="photo-upload" className="cursor-pointer block p-8 border-2 border-dashed border-gray-300 rounded-lg hover:bg-gray-50">
-                            <p className="text-gray-500">Click to select photos (simulation)</p>
-                        </label>
-                        <input id="photo-upload" type="file" multiple className="hidden" />
-                        {aiLoading ? ( <div className="flex items-center justify-center space-x-2 pt-4"> <div className="w-4 h-4 rounded-full bg-rose-500 animate-pulse"></div> <p>AI is analyzing...</p> </div> ) : ( <button onClick={simulateAIAnalysis} className="w-full p-3 bg-rose-500 text-white rounded-lg font-semibold">Analyze My "Photos"</button> )}
+                        <ImageUpload onUpload={(url, analysis) => {
+                            setFormData(prev => ({ ...prev, photos: [url], aiAnalysis: analysis }));
+                            handleNext();
+                        }} />
                         <button onClick={handleBack} className="w-full p-3 mt-2 bg-gray-300 text-black rounded-lg font-semibold">Back</button>
                     </div>
                 );
@@ -314,9 +302,13 @@ const ProfileScreen = ({ userData, onProfileUpdate }) => {
     return (
         <div className="p-4 space-y-6">
             <div className="flex flex-col items-center space-y-2">
-                <div className="w-24 h-24 rounded-full bg-gradient-to-br from-rose-400 to-orange-300 flex items-center justify-center text-white font-bold text-4xl">
-                    {formData.name.charAt(0)}
-                </div>
+                {formData.photos && formData.photos[0] ? (
+                    <img src={formData.photos[0]} alt="Profile" className="w-24 h-24 rounded-full object-cover" />
+                ) : (
+                    <div className="w-24 h-24 rounded-full bg-gradient-to-br from-rose-400 to-orange-300 flex items-center justify-center text-white font-bold text-4xl">
+                        {formData.name.charAt(0)}
+                    </div>
+                )}
                 {isEditing ? (
                     <input name="name" value={formData.name} onChange={handleChange} className="text-2xl font-bold text-center border-b-2" />
                 ) : (

--- a/src/firebase/init.js
+++ b/src/firebase/init.js
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 // --- Firebase Configuration ---
 /**
@@ -25,5 +26,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+export const storage = getStorage(app);
 
 export default app;

--- a/src/profile/ImageUpload.js
+++ b/src/profile/ImageUpload.js
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db, storage } from '../firebase/init';
+
+async function placeholderAIAnalysis(url) {
+  await new Promise((r) => setTimeout(r, 1000));
+  return { description: 'AI analysis placeholder', tags: ['sample-tag'] };
+}
+
+export default function ImageUpload({ onUpload }) {
+  const [uploading, setUploading] = useState(false);
+
+  const handleChange = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const user = auth.currentUser;
+      if (!user) throw new Error('No user');
+      const storageRef = ref(storage, `users/${user.uid}/${file.name}`);
+      await uploadBytes(storageRef, file);
+      const url = await getDownloadURL(storageRef);
+      const analysis = await placeholderAIAnalysis(url);
+      await setDoc(doc(db, 'users', user.uid), { photos: [url], aiAnalysis: analysis }, { merge: true });
+      if (onUpload) onUpload(url, analysis);
+    } catch (err) {
+      console.error('Error uploading image:', err);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor="photo-upload" className="cursor-pointer block p-8 border-2 border-dashed border-gray-300 rounded-lg hover:bg-gray-50">
+        <p className="text-gray-500">{uploading ? 'Uploading...' : 'Click to select a photo'}</p>
+      </label>
+      <input id="photo-upload" type="file" accept="image/*" className="hidden" onChange={handleChange} />
+    </div>
+  );
+}

--- a/storage-cors.json
+++ b/storage-cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["http://localhost:3000"],
+    "method": ["GET", "POST", "PUT", "HEAD"],
+    "responseHeader": ["Content-Type", "Authorization"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## Summary
- initialize Firebase Storage and export storage instance for uploads
- add ImageUpload component that stores photos, runs placeholder AI analysis, and saves results
- integrate image upload into onboarding to replace placeholder avatar
- document storage upload feature in README
- add storage-cors.json and README instructions to configure Firebase Storage CORS

## Testing
- `npm test -- src/__tests__/auth.test.js --watchAll=false`
- `npm test -- src/__tests__/chat.test.js --watchAll=false`
- `npm test -- src/__tests__/matching.test.js --watchAll=false`
- `npm test -- src/App.test.js --watchAll=false` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68abfca533fc83218ce212ad9d5999cc