### PR TITLE
Configure Firebase Storage CORS for resumable uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ A React-based roommate matching app that uses AI analysis and Firebase for real-
    - Enable Authentication (Email/Password)
    - Enable Firestore Database and Storage
    - Copy your config values to `.env.local`
-   - Configure Firebase Storage CORS for local development using the provided `storage-cors.json`:
+   - Configure Firebase Storage CORS for local development using the provided `storage-cors.json`.
+     The configuration includes headers used by the Firebase Web SDK for resumable uploads.
 
      ```bash
      gsutil cors set storage-cors.json gs://<your-storage-bucket>

--- a/storage-cors.json
+++ b/storage-cors.json
@@ -1,8 +1,18 @@
 [
   {
     "origin": ["http://localhost:3000"],
-    "method": ["GET", "POST", "PUT", "HEAD"],
-    "responseHeader": ["Content-Type", "Authorization"],
+    "method": ["GET", "POST", "PUT", "DELETE", "HEAD"],
+    "responseHeader": [
+      "Content-Type",
+      "Authorization",
+      "x-goog-resumable",
+      "x-goog-upload-protocol",
+      "x-goog-upload-command",
+      "x-goog-upload-offset",
+      "x-goog-upload-content-type",
+      "x-goog-upload-file-name",
+      "x-firebase-storage-version"
+    ],
     "maxAgeSeconds": 3600
   }
 ]


### PR DESCRIPTION
## Summary
- allow resumable-upload headers in Firebase Storage CORS config
- document updated CORS setup in README

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac076b0ee0832181dea2c305ad24f1