### PR TITLE
Allow preflight OPTIONS in Firebase Storage CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ A React-based roommate matching app that uses AI analysis and Firebase for real-
    - Enable Authentication (Email/Password)
    - Enable Firestore Database and Storage
    - Copy your config values to `.env.local`
-   - Configure Firebase Storage CORS for local development using the provided `storage-cors.json`:
+   - Configure Firebase Storage CORS for local development using the provided `storage-cors.json`.
+     The configuration includes headers used by the Firebase Web SDK for resumable uploads.
+     Header names are case-sensitive; the `X-Goog-Upload-*` fields must match exactly.
 
      ```bash
      gsutil cors set storage-cors.json gs://<your-storage-bucket>
      ```
+    This configuration allows the `OPTIONS` preflight method and headers required
+    for resumable uploads.
 
 5. **Start the development server**
    ```bash

--- a/storage-cors.json
+++ b/storage-cors.json
@@ -1,8 +1,18 @@
 [
   {
     "origin": ["http://localhost:3000"],
-    "method": ["GET", "POST", "PUT", "HEAD"],
-    "responseHeader": ["Content-Type", "Authorization"],
+    "method": ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"],
+    "responseHeader": [
+      "Content-Type",
+      "Authorization",
+      "x-goog-resumable",
+      "X-Goog-Upload-Protocol",
+      "X-Goog-Upload-Command",
+      "X-Goog-Upload-Offset",
+      "X-Goog-Upload-Content-Type",
+      "X-Goog-Upload-File-Name",
+      "X-Firebase-Storage-Version"
+    ],
     "maxAgeSeconds": 3600
   }
 ]


### PR DESCRIPTION
## Summary
- include OPTIONS in storage-cors.json methods so preflight requests succeed
- note OPTIONS support in README
- use canonical `X-Goog-Upload-*` header names in the CORS config and document header case sensitivity

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac076b0ee0832181dea2c305ad24f1