### PR TITLE
feat: add app-wide theme provider

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { playNotificationSound } from './notifications/notifications';
 import OnboardingScreen from './onboarding/OnboardingScreen';
 import Footer from './layout/Footer';
 import ProfileScreen from './profile/ProfileScreen';
+import { useTheme } from './theme';
 
 // --- Main App Component ---
 export default function App() {
@@ -23,6 +24,7 @@ export default function App() {
 
 function AppRoutes() {
   const { user, userData, loading } = useAuth();
+  const theme = useTheme();
   const [unreadMessageCount, setUnreadMessageCount] = useState(0);
   const [hasNewMatch, setHasNewMatch] = useState(false);
   const prevUnreadCountRef = useRef(0);
@@ -81,8 +83,21 @@ function AppRoutes() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen bg-gray-100">
-        <div className="text-xl font-semibold">Loading Your Perfect Match...</div>
+      <div
+        className="flex items-center justify-center h-screen"
+        style={{
+          backgroundColor: theme.colors.background,
+          fontFamily: theme.typography.fonts.body,
+        }}
+      >
+        <div
+          style={{
+            fontSize: theme.typography.sizes.heading,
+            fontWeight: theme.typography.weights.bold,
+          }}
+        >
+          Loading Your Perfect Match...
+        </div>
       </div>
     );
   }
@@ -96,8 +111,17 @@ function AppRoutes() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 font-sans">
-      <div className="max-w-md mx-auto bg-white shadow-lg h-screen flex flex-col">
+    <div
+      className="min-h-screen"
+      style={{
+        backgroundColor: theme.colors.background,
+        fontFamily: theme.typography.fonts.body,
+      }}
+    >
+      <div
+      className="max-w-md mx-auto shadow-lg h-screen flex flex-col"
+      style={{ backgroundColor: theme.colors.surface }}
+      >
         <Header />
         <main className="flex-1 overflow-y-auto">
           <Routes>
@@ -118,7 +142,23 @@ function AppRoutes() {
 
 
 
-const Header = () => (<header className="flex items-center justify-center p-4 border-b"><h1 className="text-2xl font-bold text-rose-500">RoomieAI</h1></header>);
+export const Header = () => {
+  const theme = useTheme();
+  return (
+    <header className="flex items-center justify-center p-4 border-b">
+      <h1
+        style={{
+          fontSize: theme.typography.sizes.title,
+          fontWeight: theme.typography.weights.bold,
+          color: theme.colors.primary,
+          fontFamily: theme.typography.fonts.heading,
+        }}
+      >
+        RoomieAI
+      </h1>
+    </header>
+  );
+};
 
 
 

--- a/src/__tests__/theme.test.js
+++ b/src/__tests__/theme.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, theme } from '../theme';
+import { Header } from '../App';
+
+test('Header uses theme tokens', () => {
+  render(
+    <ThemeProvider>
+      <Header />
+    </ThemeProvider>
+  );
+  const title = screen.getByText(/RoomieAI/i);
+  expect(title).toHaveStyle(`color: ${theme.colors.primary}`);
+  expect(title).toHaveStyle(`font-family: ${theme.typography.fonts.heading}`);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { StoreProvider } from './state/Store';
+import { ThemeProvider } from './theme';
 
 // Support both SENTRY_DSN and REACT_APP_SENTRY_DSN for CRA compatibility
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.REACT_APP_SENTRY_DSN;
@@ -16,7 +17,9 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <StoreProvider>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </StoreProvider>
   </React.StrictMode>
 );

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,36 @@
+import React, { createContext, useContext } from 'react';
+
+export const theme = {
+  colors: {
+    background: '#fefae0', // soft yellow
+    surface: '#ffffff',
+    primary: '#a8dadc', // soft blue
+    secondary: '#b5e48c', // soft green
+    text: '#2f3e46'
+  },
+  typography: {
+    fonts: {
+      body: "'Helvetica Neue', Arial, sans-serif",
+      heading: "'Georgia', serif"
+    },
+    sizes: {
+      body: '1rem',
+      heading: '1.25rem',
+      title: '2rem'
+    },
+    weights: {
+      regular: 400,
+      bold: 700
+    }
+  }
+};
+
+const ThemeContext = createContext(theme);
+
+export const ThemeProvider = ({ children }) => (
+  <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+);
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default theme;


### PR DESCRIPTION
## Summary
- define warm color palette and typography hierarchy in new theme module
- wrap application with ThemeProvider and consume tokens in App header and layout
- add test ensuring header uses theme tokens

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad042f49148321ae87ed263b99d38c