### PR TITLE
feat: add custom navigation icons

### DIFF
--- a/src/assets/icons/passport.svg
+++ b/src/assets/icons/passport.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <rect x="5" y="3" width="14" height="18" rx="2" />
+  <circle cx="12" cy="10" r="3" />
+  <path d="M9 14h6" />
+</svg>

--- a/src/assets/icons/smiling-house.svg
+++ b/src/assets/icons/smiling-house.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M3 10l9-7 9 7v10a2 2 0 0 1-2 2h-4v-6H9v6H5a2 2 0 0 1-2-2V10z" />
+  <path d="M9 14s1 2 3 2 3-2 3-2" stroke="currentColor" stroke-width="1" fill="none" stroke-linecap="round" />
+</svg>

--- a/src/assets/icons/sofa.svg
+++ b/src/assets/icons/sofa.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 10V7a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v3" />
+  <rect x="2" y="10" width="20" height="7" rx="2" />
+  <path d="M2 17h2v3H2zm18 0h2v3h-2z" />
+</svg>

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { HeartIcon, ChatIcon, UserIcon } from '../icons';
+import { ReactComponent as SofaIcon } from '../assets/icons/sofa.svg';
+import { ReactComponent as PassportIcon } from '../assets/icons/passport.svg';
+import { ReactComponent as SmilingHouseIcon } from '../assets/icons/smiling-house.svg';
 import { playNotificationSound } from '../notifications/notifications';
 
 const Footer = ({ unreadMessageCount, hasNewMatch }) => {
@@ -16,21 +18,24 @@ const Footer = ({ unreadMessageCount, hasNewMatch }) => {
         {
             name: 'match',
             to: '/matches',
-            icon: HeartIcon,
-            showNotification: hasNewMatch
+            icon: SmilingHouseIcon,
+            showNotification: hasNewMatch,
+            ariaLabel: 'matches'
         },
         {
             name: 'chats',
             to: '/chats',
-            icon: ChatIcon,
+            icon: SofaIcon,
             showNotification: unreadMessageCount > 0,
-            notificationCount: unreadMessageCount
+            notificationCount: unreadMessageCount,
+            ariaLabel: 'chats'
         },
         {
             name: 'profile',
             to: '/profile',
-            icon: UserIcon,
-            showNotification: false
+            icon: PassportIcon,
+            showNotification: false,
+            ariaLabel: 'profile'
         },
     ];
 
@@ -40,7 +45,11 @@ const Footer = ({ unreadMessageCount, hasNewMatch }) => {
                 <NavLink key={item.name} to={item.to} className="relative p-2 rounded-full hover:bg-gray-100 transition-colors">
                     {({ isActive }) => (
                         <>
-                            <item.icon className={`w-7 h-7 ${isActive ? 'text-rose-500' : 'text-gray-400'}`} />
+                            <item.icon
+                                aria-label={item.ariaLabel}
+                                role="img"
+                                className={`w-7 h-7 ${isActive ? 'text-rose-500' : 'text-gray-400'}`}
+                            />
                             {/* New Match Indicator */}
                             {item.showNotification && item.name === 'match' && (
                                 <span className="absolute -top-1 -right-1 block h-3 w-3 rounded-full ring-2 ring-white bg-yellow-500 notification-pulse notification-bubble"></span>


### PR DESCRIPTION
## Summary
- add sofa, passport and smiling house SVGs
- update footer to use new icons with aria labels for accessibility

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad05e843488321af39374741de3dff