### PR TITLE
feat: refine theme and apply soft palette

### DIFF
--- a/src/__tests__/matchView.test.js
+++ b/src/__tests__/matchView.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, theme } from '../theme';
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  getDoc: jest.fn(),
+  updateDoc: jest.fn(),
+  arrayUnion: jest.fn(),
+  serverTimestamp: jest.fn(),
+  collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  getDocs: jest.fn().mockResolvedValue({ forEach: jest.fn() }),
+}));
+
+jest.mock('../notifications/notifications', () => ({
+  playNotificationSound: jest.fn(),
+}));
+
+jest.mock('../firebase/init', () => ({
+  db: {},
+  auth: {},
+  storage: {},
+}));
+
+import MatchView from '../matching/MatchView';
+
+const dummyUser = {
+  uid: '1',
+  matchingPreferences: { gender: [] },
+  likes: [],
+  passes: [],
+};
+
+describe('MatchView layout', () => {
+  it('uses theme colors and typography', () => {
+    render(
+      <ThemeProvider>
+        <MatchView currentUserData={dummyUser} />
+      </ThemeProvider>
+    );
+    const loading = screen.getByText('Finding potential roomies...');
+    expect(loading).toHaveStyle(`color: ${theme.colors.textPrimary}`);
+  });
+});

--- a/src/layout/Footer.js
+++ b/src/layout/Footer.js
@@ -4,9 +4,11 @@ import { ReactComponent as SofaIcon } from '../assets/icons/sofa.svg';
 import { ReactComponent as PassportIcon } from '../assets/icons/passport.svg';
 import { ReactComponent as SmilingHouseIcon } from '../assets/icons/smiling-house.svg';
 import { playNotificationSound } from '../notifications/notifications';
+import { useTheme } from '../theme';
 
 const Footer = ({ unreadMessageCount, hasNewMatch }) => {
     console.log('🔔 Footer render - unreadMessageCount:', unreadMessageCount, 'hasNewMatch:', hasNewMatch);
+    const theme = useTheme();
 
     const testNotification = () => {
         console.log('🧪 Testing notification system...');
@@ -40,23 +42,40 @@ const Footer = ({ unreadMessageCount, hasNewMatch }) => {
     ];
 
     return (
-        <footer className="flex justify-around p-2 border-t bg-white">
+        <footer
+            className="flex justify-around p-2 border-t"
+            style={{ backgroundColor: theme.colors.surface }}
+        >
             {navItems.map(item => (
-                <NavLink key={item.name} to={item.to} className="relative p-2 rounded-full hover:bg-gray-100 transition-colors">
+                <NavLink key={item.name} to={item.to} className="relative p-2 rounded-full">
                     {({ isActive }) => (
                         <>
                             <item.icon
                                 aria-label={item.ariaLabel}
                                 role="img"
-                                className={`w-7 h-7 ${isActive ? 'text-rose-500' : 'text-gray-400'}`}
+                                className="w-7 h-7"
+                                style={{ color: isActive ? theme.colors.primary : theme.colors.textSecondary }}
                             />
                             {/* New Match Indicator */}
                             {item.showNotification && item.name === 'match' && (
-                                <span className="absolute -top-1 -right-1 block h-3 w-3 rounded-full ring-2 ring-white bg-yellow-500 notification-pulse notification-bubble"></span>
+                                <span
+                                    className="absolute -top-1 -right-1 block h-3 w-3 rounded-full notification-pulse notification-bubble"
+                                    style={{
+                                        backgroundColor: theme.colors.secondary,
+                                        boxShadow: `0 0 0 2px ${theme.colors.surface}`,
+                                    }}
+                                ></span>
                             )}
                             {/* Unread Message Indicator */}
                             {item.showNotification && item.name === 'chats' && (
-                                <span className="absolute -top-1 -right-1 block h-5 w-5 rounded-full ring-2 ring-white bg-red-500 text-white text-xs font-bold flex items-center justify-center notification-bounce notification-bubble">
+                                <span
+                                    className="absolute -top-1 -right-1 block h-5 w-5 rounded-full text-xs font-bold flex items-center justify-center notification-bounce notification-bubble"
+                                    style={{
+                                        backgroundColor: theme.colors.accent,
+                                        color: theme.colors.surface,
+                                        boxShadow: `0 0 0 2px ${theme.colors.surface}`,
+                                    }}
+                                >
                                     {item.notificationCount > 99 ? '99+' : item.notificationCount}
                                 </span>
                             )}
@@ -67,7 +86,8 @@ const Footer = ({ unreadMessageCount, hasNewMatch }) => {
             {/* Debug button */}
             <button
                 onClick={testNotification}
-                className="p-2 rounded-full bg-gray-200 hover:bg-gray-300 transition-colors text-xs"
+                className="p-2 rounded-full text-xs"
+                style={{ backgroundColor: theme.colors.background }}
                 title="Test notifications"
             >
                 🧪

--- a/src/matching/MatchView.js
+++ b/src/matching/MatchView.js
@@ -179,6 +179,7 @@ const MatchView = ({ currentUserData }) => {
 
   return (
     <div
+      data-testid="match-view"
       className="h-full flex flex-col justify-between"
       style={{
         padding: theme.spacing.lg,
@@ -196,7 +197,8 @@ const MatchView = ({ currentUserData }) => {
         />
       )}
       <div
-        className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-lg bg-gray-300 cursor-pointer transform transition-transform hover:scale-[1.02]"
+        className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-lg cursor-pointer transform transition-transform hover:scale-[1.02]"
+        style={{ backgroundColor: theme.colors.surface }}
         onClick={() => setShowDetailedProfile(true)}
       >
         <div
@@ -205,14 +207,18 @@ const MatchView = ({ currentUserData }) => {
             background: `linear-gradient(135deg, ${theme.colors.primary}, ${theme.colors.secondary})`,
           }}
         >
-          <span className="text-6xl font-bold text-white">{currentProfile.name.charAt(0)}</span>
+          <span className="text-6xl font-bold" style={{ color: theme.colors.surface }}>
+            {currentProfile.name.charAt(0)}
+          </span>
         </div>
-        <div className="absolute bottom-0 left-0 w-full h-1/3 bg-gradient-to-t from-black/70 to-transparent p-4 flex flex-col justify-end">
-          <h3 className="text-white text-3xl font-bold">{currentProfile.name}, {currentProfile.age}</h3>
-          <p
-            className="font-bold text-lg"
-            style={{ color: theme.colors.success }}
-          >
+        <div
+          className="absolute bottom-0 left-0 w-full h-1/3 p-4 flex flex-col justify-end"
+          style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.7), transparent)' }}
+        >
+          <h3 className="text-3xl font-bold" style={{ color: theme.colors.surface }}>
+            {currentProfile.name}, {currentProfile.age}
+          </h3>
+          <p className="font-bold text-lg" style={{ color: theme.colors.success }}>
             {currentProfile.compatibility}% Match
           </p>
           
@@ -220,7 +226,11 @@ const MatchView = ({ currentUserData }) => {
           {currentProfile.compatibilityInsights && currentProfile.compatibilityInsights.length > 0 && (
             <div className="mt-2 space-y-1">
               {currentProfile.compatibilityInsights.map((insight, index) => (
-                <div key={index} className="flex items-center text-white/90 text-sm">
+                <div
+                  key={index}
+                  className="flex items-center text-sm"
+                  style={{ color: theme.colors.surface, opacity: 0.9 }}
+                >
                   <span className="mr-2">{insight.icon}</span>
                   <span className="font-medium">{insight.text}</span>
                 </div>
@@ -244,8 +254,13 @@ const MatchView = ({ currentUserData }) => {
           </div>
           
           {/* Tap to view more indicator */}
-          <div className="absolute top-4 right-4 bg-white/20 backdrop-blur-sm px-3 py-1 rounded-full">
-            <span className="text-white text-xs font-medium">Tap to view more</span>
+          <div
+            className="absolute top-4 right-4 px-3 py-1 rounded-full"
+            style={{ backgroundColor: `${theme.colors.surface}33`, backdropFilter: 'blur(4px)' }}
+          >
+            <span className="text-xs font-medium" style={{ color: theme.colors.surface }}>
+              Tap to view more
+            </span>
           </div>
         </div>
       </div>
@@ -304,7 +319,10 @@ const MatchModal = ({ otherUser, onClose }) => {
   }, []);
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+    <div
+      className="fixed inset-0 flex items-center justify-center z-50 p-4"
+      style={{ backgroundColor: `${theme.colors.textPrimary}80` }}
+    >
       <div
         className="rounded-2xl p-8 text-center shadow-xl transform transition-all scale-100 opacity-100 relative"
         style={{ backgroundColor: theme.colors.surface }}
@@ -321,15 +339,23 @@ const MatchModal = ({ otherUser, onClose }) => {
         </p>
         <div className="flex justify-center items-center my-6 space-x-4">
           <div
-            className="w-20 h-20 rounded-full flex items-center justify-center text-white font-bold text-3xl ring-4 ring-white shadow-md"
-            style={{ background: `linear-gradient(135deg, ${theme.colors.accent}, ${theme.colors.secondary})` }}
+            className="w-20 h-20 rounded-full flex items-center justify-center font-bold text-3xl shadow-md"
+            style={{
+              background: `linear-gradient(135deg, ${theme.colors.accent}, ${theme.colors.secondary})`,
+              color: theme.colors.surface,
+              boxShadow: `0 0 0 4px ${theme.colors.surface}`
+            }}
           >
             Y
           </div>
           <HeartIcon className="w-10 h-10" style={{ color: theme.colors.accent }} />
           <div
-            className="w-20 h-20 rounded-full flex items-center justify-center text-white font-bold text-3xl ring-4 ring-white shadow-md"
-            style={{ background: `linear-gradient(135deg, ${theme.colors.primary}, ${theme.colors.secondary})` }}
+            className="w-20 h-20 rounded-full flex items-center justify-center font-bold text-3xl shadow-md"
+            style={{
+              background: `linear-gradient(135deg, ${theme.colors.primary}, ${theme.colors.secondary})`,
+              color: theme.colors.surface,
+              boxShadow: `0 0 0 4px ${theme.colors.surface}`
+            }}
           >
             {otherUser.name.charAt(0)}
           </div>
@@ -370,21 +396,34 @@ const DetailedProfileModal = ({ profile, onClose, onSwipe }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+    <div
+      className="fixed inset-0 flex items-center justify-center z-50 p-4"
+      style={{ backgroundColor: `${theme.colors.textPrimary}80` }}
+    >
       <div
         className="rounded-2xl max-w-md w-full max-h-[90vh] overflow-y-auto shadow-xl"
         style={{ backgroundColor: theme.colors.surface }}
       >
         {/* Header */}
         <div
-          className="relative p-6 text-white"
-          style={{ background: `linear-gradient(135deg, ${theme.colors.primary}, ${theme.colors.secondary})` }}
+          className="relative p-6"
+          style={{
+            background: `linear-gradient(135deg, ${theme.colors.primary}, ${theme.colors.secondary})`,
+            color: theme.colors.surface,
+          }}
         >
-          <button onClick={onClose} className="absolute top-4 right-4 text-white/80 hover:text-white">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4"
+            style={{ color: theme.colors.surface, opacity: 0.8 }}
+          >
             <XIcon className="w-6 h-6" />
           </button>
           <div className="text-center">
-            <div className="w-24 h-24 mx-auto mb-4 rounded-full bg-white/20 flex items-center justify-center text-white font-bold text-5xl">
+            <div
+              className="w-24 h-24 mx-auto mb-4 rounded-full flex items-center justify-center font-bold text-5xl"
+              style={{ backgroundColor: `${theme.colors.surface}33`, color: theme.colors.surface }}
+            >
               {profile.name.charAt(0)}
             </div>
             <h2 className="text-3xl font-bold">{profile.name}, {profile.age}</h2>
@@ -505,7 +544,11 @@ const DetailedProfileModal = ({ profile, onClose, onSwipe }) => {
               </h3>
               <div className="space-y-2">
                 {profile.compatibilityInsights.map((insight, index) => (
-                  <div key={index} className="flex items-center p-3 bg-green-50 rounded-lg">
+                  <div
+                    key={index}
+                    className="flex items-center p-3 rounded-lg"
+                    style={{ backgroundColor: `${theme.colors.secondary}33` }}
+                  >
                     <span className="text-2xl mr-3">{insight.icon}</span>
                     <span className="font-medium" style={{ color: theme.colors.success }}>
                       {insight.text}

--- a/src/profile/ImageUpload.js
+++ b/src/profile/ImageUpload.js
@@ -3,9 +3,11 @@ import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { doc, setDoc } from 'firebase/firestore';
 import { auth, db, storage } from '../firebase/init';
 import { analyzeImage } from '../ai/photoAnalysis';
+import { useTheme } from '../theme';
 
 export default function ImageUpload({ onUpload }) {
   const [uploading, setUploading] = useState(false);
+  const theme = useTheme();
 
   const handleChange = async (e) => {
     const file = e.target.files[0];
@@ -29,8 +31,17 @@ export default function ImageUpload({ onUpload }) {
 
   return (
     <div className="space-y-2">
-      <label htmlFor="photo-upload" className="cursor-pointer block p-8 border-2 border-dashed border-gray-300 rounded-lg hover:bg-gray-50">
-        <p className="text-gray-500">{uploading ? 'Uploading...' : 'Click to select a photo'}</p>
+      <label
+        htmlFor="photo-upload"
+        className="cursor-pointer block p-8 border-2 border-dashed rounded-lg"
+        style={{
+          borderColor: theme.colors.textSecondary,
+          backgroundColor: theme.colors.surface,
+        }}
+      >
+        <p style={{ color: theme.colors.textSecondary }}>
+          {uploading ? 'Uploading...' : 'Click to select a photo'}
+        </p>
       </label>
       <input id="photo-upload" type="file" accept="image/*" className="hidden" onChange={handleChange} />
     </div>

--- a/src/profile/ProfileScreen.js
+++ b/src/profile/ProfileScreen.js
@@ -37,8 +37,11 @@ const ProfileScreen = ({ userData, onProfileUpdate }) => {
           <img src={formData.photos[0]} alt="Profile" className="w-24 h-24 rounded-full object-cover" />
         ) : (
           <div
-            className="w-24 h-24 rounded-full flex items-center justify-center text-white font-bold text-4xl"
-            style={{ background: `linear-gradient(135deg, ${theme.colors.accent}, ${theme.colors.secondary})` }}
+            className="w-24 h-24 rounded-full flex items-center justify-center font-bold text-4xl"
+            style={{
+              background: `linear-gradient(135deg, ${theme.colors.accent}, ${theme.colors.secondary})`,
+              color: theme.colors.surface,
+            }}
           >
             {formData.name.charAt(0)}
           </div>

--- a/src/theme.js
+++ b/src/theme.js
@@ -2,13 +2,13 @@ import React, { createContext, useContext } from 'react';
 
 export const theme = {
   colors: {
-    background: '#f8f9fa',
+    background: '#f0f4f8',
     surface: '#ffffff',
-    primary: '#6c63ff',
-    secondary: '#ffd166',
-    accent: '#ef476f',
-    success: '#06d6a0',
-    danger: '#e63946',
+    primary: '#7cb1e8',
+    secondary: '#a8e6cf',
+    accent: '#fff3b0',
+    success: '#81c784',
+    danger: '#ff8a80',
     textPrimary: '#2d3142',
     textSecondary: '#4f5d75'
   },
@@ -21,7 +21,7 @@ export const theme = {
   },
   typography: {
     fonts: {
-      body: "'Helvetica Neue', Arial, sans-serif",
+      body: "'Inter', 'Helvetica Neue', Arial, sans-serif",
       heading: "'Georgia', serif"
     },
     sizes: {


### PR DESCRIPTION
## Summary
- adopt soft blue, green, and yellow palette and set Inter as body font
- replace hard-coded colors with theme usage in Footer, MatchView, Profile, and ImageUpload components
- add test to verify MatchView uses theme styles

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68ad19c85a4483219981a00906593495