### PR TITLE
feat: make profile tags editable

### DIFF
--- a/src/__tests__/profileScreen.test.js
+++ b/src/__tests__/profileScreen.test.js
@@ -1,6 +1,17 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('firebase/firestore', () => ({
+  __esModule: true,
+  doc: jest.fn(() => ({})),
+  updateDoc: jest.fn(),
+  getFirestore: jest.fn(() => ({})),
+}));
+
+import { updateDoc } from 'firebase/firestore';
 import ProfileScreen from '../profile/ProfileScreen';
-import { ThemeProvider, theme } from '../theme';
+import { ThemeProvider } from '../theme';
+import { auth } from '../firebase/init';
 
 describe('ProfileScreen layout', () => {
   const userData = {
@@ -9,6 +20,10 @@ describe('ProfileScreen layout', () => {
     aiAnalysis: { tags: ['clean', 'quiet'] },
     photos: [],
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('renders profile header and sections', () => {
     render(
@@ -19,5 +34,40 @@ describe('ProfileScreen layout', () => {
     expect(screen.getByText('My Profile')).toBeInTheDocument();
     expect(screen.getByText('About Me')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Edit/i })).toBeInTheDocument();
+  });
+
+  it('adds a tag', async () => {
+    auth.currentUser = { uid: 'abc' };
+    render(
+      <ThemeProvider>
+        <ProfileScreen userData={userData} onProfileUpdate={jest.fn()} />
+      </ThemeProvider>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Edit/i }));
+    const input = screen.getByPlaceholderText('Add tag');
+    await userEvent.type(input, 'friendly{enter}');
+    expect(screen.getByText('friendly')).toBeInTheDocument();
+    await waitFor(() => expect(updateDoc).toHaveBeenCalled());
+    expect(updateDoc.mock.calls[0][1]).toEqual({
+      'aiAnalysis.tags': ['clean', 'quiet', 'friendly'],
+    });
+  });
+
+  it('removes a tag', async () => {
+    auth.currentUser = { uid: 'abc' };
+    render(
+      <ThemeProvider>
+        <ProfileScreen userData={userData} onProfileUpdate={jest.fn()} />
+      </ThemeProvider>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /Edit/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove clean' }));
+    expect(screen.queryByText('clean')).not.toBeInTheDocument();
+    await waitFor(() => expect(updateDoc).toHaveBeenCalled());
+    expect(updateDoc.mock.calls[0][1]).toEqual({
+      'aiAnalysis.tags': ['quiet'],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- make profile tags editable chips with delete icons
- persist tag changes to Firestore
- test adding and removing tags

## Testing
- `npm test src/__tests__/profileScreen.test.js -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad292a85d48321bd0d8826fa84462c