### PR TITLE
Add AI personality profile summary and test

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -71,12 +71,14 @@ function AppRoutes() {
     }
   }, [location.pathname, hasNewMatch]);
 
-  const handleProfileUpdate = async (newData) => {
+  const handleProfileUpdate = async (newData, options = {}) => {
     if (!user) return;
     try {
       const userDocRef = doc(db, 'users', user.uid);
       await setDoc(userDocRef, newData, { merge: true });
-      navigate('/matches');
+      if (!options.skipNavigate) {
+        navigate('/matches');
+      }
     } catch (error) {
       console.error('Error updating profile:', error);
       Sentry.captureException(error);

--- a/src/__tests__/onboardingSummary.test.js
+++ b/src/__tests__/onboardingSummary.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import OnboardingScreen from '../onboarding/OnboardingScreen';
+
+jest.mock('@sentry/react', () => ({ captureException: jest.fn(), init: jest.fn() }));
+
+jest.mock('../profile/ImageUpload', () => {
+  const React = require('react');
+  return (props) => {
+    React.useEffect(() => {
+      props.onUpload('http://example.com/photo.jpg', {
+        description: 'Smiling friend',
+        tags: ['friendly', 'smiling'],
+      });
+    }, []);
+    return <div>mock upload</div>;
+  };
+});
+
+jest.mock('../firebase/init', () => ({
+  auth: { currentUser: { uid: '123' } },
+  db: {}
+}));
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(() => ({})),
+  getDoc: jest.fn(() =>
+    Promise.resolve({
+      data: () => ({
+        aiAnalysis: { description: 'Smiling friend', tags: ['friendly', 'smiling'] },
+      }),
+    })
+  ),
+}));
+
+describe('Onboarding summary flow', () => {
+  it('shows AI personality profile after finishing onboarding', async () => {
+    const mockUpdate = jest.fn(() => Promise.resolve());
+    render(
+      <MemoryRouter>
+        <OnboardingScreen onProfileUpdate={mockUpdate} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('Next'));
+    fireEvent.click(screen.getByText('Next'));
+    fireEvent.click(screen.getByText('Next'));
+
+    const finishButton = screen.getByText('Finish');
+    await waitFor(() => expect(finishButton).not.toBeDisabled());
+    fireEvent.click(finishButton);
+
+    expect(mockUpdate).toHaveBeenCalled();
+    await screen.findByText('AI Personality Profile');
+    expect(screen.getByText('Smiling friend')).toBeInTheDocument();
+    expect(screen.getByText('friendly')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show AI Personality Profile summary after onboarding photo upload
- defer match navigation and fetch analysis data from backend
- cover onboarding flow with test validating summary display

## Testing
- `CI=true npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68af9110caf08321a3cbfcf510574f9d